### PR TITLE
Get away from master and slave lingo

### DIFF
--- a/hadoop_job_runner.py
+++ b/hadoop_job_runner.py
@@ -52,8 +52,8 @@ jobname = 'MM Logs Jobflow %s' %dt.datetime.now()
 jobid = conne.run_jobflow(name=jobname,
                           log_uri='s3://dphive/debug/',
                           ec2_keyname='dpaws',
-                          master_instance_type='c1.medium',
-                          slave_instance_type='c1.medium',
+                          main_instance_type='c1.medium',
+                          subordinate_instance_type='c1.medium',
                           num_instances=3,
                           steps=[step1, step2])
 

--- a/prod/cdo/google/bin/build/pyodbc/setup.py
+++ b/prod/cdo/google/bin/build/pyodbc/setup.py
@@ -253,7 +253,7 @@ def _get_version_git():
 
     n, result = getoutput('git branch')
     branch = re.search(r'\* (\w+)', result).group(1)
-    if branch != 'master' and not re.match('^v\d+$', branch):
+    if branch != 'main' and not re.match('^v\d+$', branch):
         name = branch + '-' + name
 
     return name, numbers


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.